### PR TITLE
1.그룹탈퇴하기

### DIFF
--- a/src/main/java/fs/project/controller/TeamController.java
+++ b/src/main/java/fs/project/controller/TeamController.java
@@ -284,9 +284,6 @@ public class TeamController extends BaseEntity {
         }
 
 
-
-
-
         return res;
     }
 
@@ -335,7 +332,6 @@ public class TeamController extends BaseEntity {
 
 
         //        ===================임시 로그인 계정 _ 앞단이랑 연결하면 유저아이디로 UID 찾아서 넣으면 될 것 같다.==================
-
 
 
         return "redirect:/";

--- a/src/main/java/fs/project/repository/UserTeamRepository.java
+++ b/src/main/java/fs/project/repository/UserTeamRepository.java
@@ -60,7 +60,7 @@ public class UserTeamRepository {
     public boolean findDropTeam(Long tid) {
         List<UserTeam> all = findAll();
         for (UserTeam ut : all) {
-            if (ut.getTeam().getTID().equals(tid)) {
+            if (ut.getTeam().getTID().equals(tid)&&ut.isJoinUs()==true) { //현재 가입요청을 제외한 사람들만
                 //Team의 boss를 찾은 uid 값을 넣는다.
                 String s = "update Team t set t.boss = :uid where t.tID = :tid";
                 em.createQuery(s).setParameter("uid",ut.getUser().getUID()).setParameter("tid", tid).executeUpdate();
@@ -73,5 +73,14 @@ public class UserTeamRepository {
     public void dropTeam(Long tid) {
         String s = "delete from Team t where t.tID = :tid ";
         em.createQuery(s).setParameter("tid",tid).executeUpdate();
+        //만약 팀이 사라졌다면 가입요청한 사람들 모두 지우기
+        List<UserTeam> all = findAll();
+        for (UserTeam ut : all) {
+            if (ut.getTeam().getTID().equals(tid)&&ut.isJoinUs()==false) {
+                //Team의 boss를 찾은 uid 값을 넣는다.
+                String s1 = "delete from UserTeam ut where t.tID = :tid";
+                em.createQuery(s).setParameter("tid",tid).executeUpdate();
+            }
+        }
     }
 }

--- a/src/main/java/fs/project/service/UserService.java
+++ b/src/main/java/fs/project/service/UserService.java
@@ -102,6 +102,7 @@ public class UserService {
 
         if(check==false){//team 을 그냥 지워라.
 
+
             userTeamRepository.dropTeam(tid);
 
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     # show-sql:
 
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         # show_sql: true


### PR DESCRIPTION
2.메인그룹 변경하기
3.그룹장이였을 때 그룹 탈퇴시 그룹장 다른 팀원에게 넘겨주기
4.그룹 탈퇴했는데 아무도 없으면 팀테이블, 유저테이블 날리기
5.메인그룹을 2번으로 설정 해놨는데 팀을 탈퇴했을 때 메인 그룹을 랜덤으로 설정
- user의 main_tid가 삭제할 user_team에 tid와 같다면 user가 속한 uid값을 들고 있는 user_team의 uid가 일치하는 값이 하나라도 존재한다면 그걸 main_tid로 둔다.
6.그룹 설정 페이지_그룹 구성원 ui수정
7.그룹장 페이지에서 현재 그룹장이 누구인지 표시